### PR TITLE
[FEAT] 커스텀 모달

### DIFF
--- a/Chaap/Chaap/Common/Components/CHBottomModalModifier.swift
+++ b/Chaap/Chaap/Common/Components/CHBottomModalModifier.swift
@@ -1,0 +1,79 @@
+//
+//  CHBottomModalModifier.swift
+//  Chaap
+//
+//  Created by BoMin Lee on 7/18/25.
+//
+
+import SwiftUI
+
+struct CHBottomModalModifier<SheetContent: View>: ViewModifier {
+    @Binding var isPresented: Bool
+        @GestureState private var dragOffset: CGFloat = 0
+
+        let minHeight: CGFloat
+        let maxHeight: CGFloat
+        let content: () -> SheetContent
+
+        func body(content base: Content) -> some View {
+            ZStack {
+                base
+                    .onTapGesture {
+                        withAnimation {
+                            isPresented = false
+                        }
+                    }
+                if isPresented {
+                    // MARK: 모달 아래 배경에 dim 효과 주는 코드인데, 쓰이지 않는 것 같아 우선 주석 처리
+//                    Color.black.opacity(0.3)
+//                        .ignoresSafeArea()
+//                        .onTapGesture {
+//                            withAnimation { isPresented = false }
+//                        }
+                    sheetView()
+                        .transition(.move(edge: .bottom))
+                        .animation(.easeInOut, value: isPresented)
+                }
+            }
+        }
+
+        @ViewBuilder
+        private func sheetView() -> some View {
+            GeometryReader { geometry in
+                let defaultHeight = maxHeight
+                VStack {
+                    Spacer()
+                    VStack {
+                        Capsule()
+                            .frame(width: 40, height: 4)
+                            .foregroundColor(.white)
+                            .padding(.top, 12)
+                        self.content()
+                            .padding()
+                    }
+                    .frame(width: geometry.size.width, height: defaultHeight - dragOffset)
+                    // TODO: 배경 Glass Morphism 적용해야 함.
+                    .background(Color.red.opacity(0.3))
+                    .cornerRadius(36)
+                    .shadow(radius: 10)
+                    .offset(y: dragOffset)
+                    .gesture(
+                        DragGesture()
+                            .updating($dragOffset) { value, state, _ in
+                                if value.translation.height > 0 {
+                                    state = value.translation.height
+                                }
+                            }
+                            .onEnded { value in
+                                if value.translation.height > 150 {
+                                    withAnimation {
+                                        isPresented = false
+                                    }
+                                }
+                            }
+                    )
+                }
+                .ignoresSafeArea(.all, edges: .bottom)
+            }
+        }
+}

--- a/Chaap/Chaap/Common/Extension/View+Extension.swift
+++ b/Chaap/Chaap/Common/Extension/View+Extension.swift
@@ -1,0 +1,25 @@
+//
+//  View+Extension.swift
+//  Chaap
+//
+//  Created by BoMin Lee on 7/18/25.
+//
+
+import SwiftUI
+
+/// Extension for CHBottomModalModifier
+extension View {
+    func chBottomModal<SheetContent: View>(
+        isPresented: Binding<Bool>,
+        minHeight: CGFloat = 200,
+        maxHeight: CGFloat = 400,
+        @ViewBuilder content: @escaping () -> SheetContent
+    ) -> some View {
+        self.modifier(CHBottomModalModifier(
+            isPresented: isPresented,
+            minHeight: minHeight,
+            maxHeight: maxHeight,
+            content: content
+        ))
+    }
+}


### PR DESCRIPTION
- CHBottomModalModifier 추가
- View Extension 추가

이슈 넘버 #10 

## 🛠️ 작업내용
CHBottomModalModifier를 추가하여, Bottom Modal이 필요한 뷰에서 사용할 수 있도록 했습니다.

https://github.com/user-attachments/assets/a9d7fc26-937b-4cab-86e5-b6af8a1c9aac



## 📌 리뷰 포인트
```swift
.chBottomModal(isPresented: $showModal, maxHeight: 500) {
    VStack {
        Button("닫기") {
            withAnimation {
                showModal = false
            }
        }
        Spacer()
    }
}
```

위와 같이 사용 가능합니다.

현재 모달의 배경은 임의로 설정해둔 상태입니다. 추후 Glass Morphism 적용 예정입니다.
